### PR TITLE
Fix build on Intel MPI compiler.

### DIFF
--- a/include/PDMlib.h
+++ b/include/PDMlib.h
@@ -9,9 +9,9 @@
 
 #ifndef PDMLIB_PDMLIB_H
 #define PDMLIB_PDMLIB_H
+#include <mpi.h>
 #include <string>
 #include <vector>
-#include <mpi.h>
 
 namespace PDMlib
 {

--- a/src/MetaData.C
+++ b/src/MetaData.C
@@ -7,14 +7,15 @@
  *
  */
 
+#include "PDMlib.h"
+#include "TextParser.h"
+
 #include <dirent.h>
 #include <algorithm>
 #include <iostream>
 #include <fstream>
 #include <list>
 #include <string>
-#include "TextParser.h"
-#include "PDMlib.h"
 #include "Utility.h"
 #include "MetaData.h"
 #include "TPWriteHelper.h"

--- a/src/PDMlib.C
+++ b/src/PDMlib.C
@@ -7,6 +7,8 @@
  *
  */
 
+#include "PDMlib.h"
+
 #include <dirent.h>
 #include <typeinfo>
 #include <string>
@@ -15,7 +17,6 @@
 #include <set>
 #include <algorithm>
 
-#include "PDMlib.h"
 #include "PDMlibImpl.h"
 #include "Write.h"
 #include "Read.h"

--- a/src/Utility.C
+++ b/src/Utility.C
@@ -7,13 +7,13 @@
  *
  */
 
+#include <mpi.h>
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
 #include <set>
 #include <string>
 #include <dirent.h>
-#include <mpi.h>
 #include "Utility.h"
 
 namespace

--- a/tools/FV14Converter.C
+++ b/tools/FV14Converter.C
@@ -7,12 +7,12 @@
  *
  */
 
+#include <mpi.h>
 #include <set>
 #include <climits>
 #include <vector>
 #include <unistd.h>
 #include <sstream>
-#include <mpi.h>
 #include "PDMlib.h"
 #include "Utility.h"
 #include "FV14Writer.h"

--- a/tools/FV14Writer.h
+++ b/tools/FV14Writer.h
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include <cstring>
 namespace FV14Writer
 {
 //! FV14 形式でファイル出力を行う関数群


### PR DESCRIPTION
This patch fixes the following error when compiling codes with Intel MPI compiler.

```
catastrophic error: #error directive: "SEEK_SET is #defined but must not
be for the C++ binding of MPI. Include mpi.h before stdio.h"
#error "SEEK_SET is #defined but must not be for the C++ binding of MPI.
Include mpi.h before stdio.h"
```