### PR TITLE
Fix project() in CMakeLists.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@
 
 cmake_minimum_required(VERSION 2.8.1)
 
-project(PDMlib CXX)
+project(PDMlib)
 
 set(CMAKE_MODULE_PATH  ${PROJECT_SOURCE_DIR}/cmake)
 

--- a/src/PDMlibImpl.h
+++ b/src/PDMlibImpl.h
@@ -15,7 +15,9 @@
 #include "Utility.h"
 #include "MetaData.h"
 #include "Read.h"
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 #include <set>
 
 //forward declaration


### PR DESCRIPTION
`project(PDMlib CXX)` will cause the following FindHDF5 error in Cmake 3.7

```
CMake Error at /usr/local/Cellar/cmake/3.7.0/share/cmake/Modules/FindHDF5.cmake:182 (try_compile):
  Unknown extension ".c" for file

    /path/to/PDMlib_build/CMakeFiles/hdf5/cmake_hdf5_test.c

  try_compile() works only for enabled languages.  Currently these are:

    CXX

  See project() command to enable other languages.
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.7.0/share/cmake/Modules/FindHDF5.cmake:468 (_HDF5_test_regular_compiler_C)
  CMakeLists.txt:113 (find_package)
```

Also fix build with a compiler which does not support OpenMP.
